### PR TITLE
Make prepl work again on older sbcl releases

### DIFF
--- a/inspect.lisp
+++ b/inspect.lisp
@@ -760,10 +760,17 @@ cons cells and LIST-TYPE is :normal, :dotted, or :cyclic"
                (cons "PLIST" (symbol-plist object)))))
     (list components (length components) :named nil)))
 
+#-sbcl
+(defun inspected-structure-parts (object)
+  '())
+
+#+sbcl
 (defun inspected-structure-parts (object)
   (let ((components-list '())
-        #+sbcl (info (sb-kernel:wrapper-info (sb-kernel:wrapper-of object))))
-    #+sbcl 
+        #+#.(prepl::with-symbol 'wrapper-info 'sb-kernel)
+        (info (sb-kernel:wrapper-info (sb-kernel:wrapper-of object)))
+        #-#.(prepl::with-symbol 'wrapper-info 'sb-kernel)
+        (info (sb-kernel:layout-info (sb-kernel:layout-of object))))
     (when (sb-kernel::defstruct-description-p info)
       (dolist (dd-slot (sb-kernel:dd-slots info) (nreverse components-list))
         (push (cons (string (sb-kernel:dsd-name dd-slot))

--- a/prepl.asd
+++ b/prepl.asd
@@ -5,6 +5,7 @@
   :components ((:file "package")
 	       (:file "prepl")
 	       (:file "commands")
+	       (:file "util")
 	       (:file "inspect"))
   :depends-on (:closer-mop :iterate :bordeaux-threads :conium
 			   :named-readtables))

--- a/util.lisp
+++ b/util.lisp
@@ -1,0 +1,37 @@
+;;; -*- show-trailing-whitespace: t; indent-tabs: nil -*-
+
+;;; Copyright (c) 2022 David Lichteblau. All rights reserved.
+
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions
+;;; are met:
+;;;
+;;;   * Redistributions of source code must retain the above copyright
+;;;     notice, this list of conditions and the following disclaimer.
+;;;
+;;;   * Redistributions in binary form must reproduce the above
+;;;     copyright notice, this list of conditions and the following
+;;;     disclaimer in the documentation and/or other materials
+;;;     provided with the distribution.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR 'AS IS' AND ANY EXPRESSED
+;;; OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+;;; WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+;;; DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+;;; GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+;;; WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+;;; NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+;;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+(cl:in-package :prepl)
+
+;;; Copied from swank-backend.lisp (Public Domain license)
+(defun with-symbol (name package)
+  "Generate a form suitable for testing with #+."
+  (if (and (find-package package)
+           (find-symbol (string name) package))
+      '(:and)
+      '(:or)))


### PR DESCRIPTION
Based on comments on https://github.com/sharplispers/prepl/pull/4 added with-symbol function to check the support for the new api.

with-symbol implementation copied from swank-backend.